### PR TITLE
Remove PID file on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN groupadd -g $HOST_GID dropbox-user && \
     useradd -ms /bin/bash -u $HOST_UID -g $HOST_GID dropbox-user  && \
     mkdir /opt/dropbox && \
     chown $HOST_UID:$HOST_GID /opt/dropbox
+COPY dropbox.sh /opt/dropbox/dropbox.sh
 
 USER dropbox-user
 WORKDIR /home/dropbox-user
@@ -24,4 +25,4 @@ RUN cd /opt/dropbox && \
 
 EXPOSE 17500
 
-ENTRYPOINT ["/opt/dropbox/.dropbox-dist/dropboxd"]
+ENTRYPOINT ["/opt/dropbox/dropbox.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN cd /home/dropbox-user && \
     curl -L "https://www.dropbox.com/download?plat=lnx.x86_64" | tar xzf - &&\
     >&2 echo "Dropbox ver.:" $(cat /opt/dropbox/.dropbox-dist/VERSION) &&\
     curl -L -o dropbox\
-    "https://www.dropbox.com/download?dl=packages/dropbox.py" &&\
-    chmod a+x /opt/dropbox/dropbox.sh
+    "https://www.dropbox.com/download?dl=packages/dropbox.py"
 
 EXPOSE 17500
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ COPY dropbox.sh /opt/dropbox/dropbox.sh
 USER dropbox-user
 WORKDIR /home/dropbox-user
 
-RUN cd /opt/dropbox && \
+RUN cd /home/dropbox-user && \
     curl -L "https://www.dropbox.com/download?plat=lnx.x86_64" | tar xzf - &&\
     >&2 echo "Dropbox ver.:" $(cat /opt/dropbox/.dropbox-dist/VERSION) &&\
     curl -L -o dropbox\
     "https://www.dropbox.com/download?dl=packages/dropbox.py" &&\
-    chmod u+x /opt/dropbox/dropbox
+    chmod a+x /opt/dropbox/dropbox.sh
 
 EXPOSE 17500
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN cd /home/dropbox-user && \
 
 EXPOSE 17500
 
-ENTRYPOINT ["/opt/dropbox/dropbox.sh"]
+ENTRYPOINT ["/bin/bash","/opt/dropbox/dropbox.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 ---
-
+version: "2"
 services:
   dropbox:
     build: "."

--- a/dropbox.sh
+++ b/dropbox.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 rm -rf /home/dropbox-user/.dropbox/dropbox.pid
-/opt/dropbox/.dropbox-dist/dropboxd
+/home/dropbox-user/.dropbox-dist/dropboxd

--- a/dropbox.sh
+++ b/dropbox.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+rm -rf /home/dropbox-user/.dropbox/dropbox.pid
+/opt/dropbox/.dropbox-dist/dropboxd


### PR DESCRIPTION
Docker would halt with `"Another instance of Dropbox (1) is running!"` if pid file exits.  Docker does not clean up pid file.

Patch removes PID file before starting Dropbox