### PR TITLE
Mitigate upgrade

### DIFF
--- a/dropbox.sh
+++ b/dropbox.sh
@@ -1,3 +1,12 @@
 #!/bin/sh
+
+# Check if upgrade happend, if so re-arange files
+if [ -d "/home/dropbox-user/.dropbox-dist" ]
+then
+    echo ERROR: Upgrade detecting, mitigating
+    rm -rf /opt/dropbox/.dropbox-dist
+    mv /home/dropbox-user/.dropbox-dist /opt/dropbox/.dropbox-dist
+fi
+
 rm -rf /home/dropbox-user/.dropbox/dropbox.pid
 /opt/dropbox/.dropbox-dist/dropboxd


### PR DESCRIPTION
Possibly fixes #2 

When upgrade is found moves files from /home to /opt.  
This will happen ever start since docker container needs to be rebuild for it to really work
But at least it should recover and not keep crashing